### PR TITLE
Added ability to specify a boolean for hideChannels to hide all channels

### DIFF
--- a/discord.js
+++ b/discord.js
@@ -153,56 +153,59 @@ var discordWidget = discordWidget || (function(){
           usersElement = $('.discord-users-online')[0];
           joinElement = $('.discord-join')[0];
 
-          if (p.alphabetical) {
-            channels = [];
-            hiddenChannels = [];
-            for (var i = 0; i < d.channels.length; i++) {
-              hideChannel = false;
-              for (var j = 0; j < p.hideChannels.length; j++) {
+          if(typeof(p.hideChannels) !== 'boolean' || !p.hideChannels) {
+            if (p.alphabetical) {
+              channels = [];
+              hiddenChannels = [];
+              for (var i = 0; i < d.channels.length; i++) {
+                hideChannel = false;
+                for (var j = 0; j < p.hideChannels.length; j++) {
+                    if (d.channels[i].name.indexOf(p.hideChannels[j]) >= 0){
+                    hideChannel = true;
+                  }
+                }
+                if (!hideChannel) {
+                  channels.push(d.channels[i]);
+                } else {
+                  hiddenChannels.push(d.channels[i].id);
+                }
+              }
+
+              for (var i = 0; i < channels.length; i++) {
+                formatted += renderChannel(channels[i].name);
+                for (var j = 0; j < d.members.length; j++) {
+                  formatted += renderUser(d.members[j], channels[i].id);
+                }
+                formatted += '</ul>';
+              }
+            } else {
+              channels = [];
+              hiddenChannels = [];
+              for (var i = 0; i < d.channels.length; i++) {
+                hideChannel = false;
+                for (var j = 0; j < p.hideChannels.length; j++) {
                   if (d.channels[i].name.indexOf(p.hideChannels[j]) >= 0){
-                  hideChannel = true;
+                    hideChannel = true;
+                  }
+                }
+                if (!hideChannel) {
+                  channels.push(d.channels[i]);
+                } else {
+                  hiddenChannels.push(d.channels[i].id);
                 }
               }
-              if (!hideChannel) {
-                channels.push(d.channels[i]);
-              } else {
-                hiddenChannels.push(d.channels[i].id);
-              }
-            }
+              channels.sort(sortChannels);
 
-            for (var i = 0; i < channels.length; i++) {
-              formatted += renderChannel(channels[i].name);
-              for (var j = 0; j < d.members.length; j++) {
-                formatted += renderUser(d.members[j], channels[i].id);
-              }
-              formatted += '</ul>';
-            }
-          } else {
-            channels = [];
-            hiddenChannels = [];
-            for (var i = 0; i < d.channels.length; i++) {
-              hideChannel = false;
-              for (var j = 0; j < p.hideChannels.length; j++) {
-                if (d.channels[i].name.indexOf(p.hideChannels[j]) >= 0){
-                  hideChannel = true;
+              for (var i = 0; i < channels.length; i++) {
+                formatted += renderChannel(channels[i].name);
+                for (var j = 0; j < d.members.length; j++) {
+                  formatted += renderUser(d.members[j], channels[i].id);
                 }
+                formatted += '</ul>';
               }
-              if (!hideChannel) {
-                channels.push(d.channels[i]);
-              } else {
-                hiddenChannels.push(d.channels[i].id);
-              }
-            }
-            channels.sort(sortChannels);
-
-            for (var i = 0; i < channels.length; i++) {
-              formatted += renderChannel(channels[i].name);
-              for (var j = 0; j < d.members.length; j++) {
-                formatted += renderUser(d.members[j], channels[i].id);
-              }
-              formatted += '</ul>';
             }
           }
+
 
           if (p.showAllUsers) {
             formatted += '<li class="discord-channel discord-allusers-toggle">&#9662; Online Users</li><ul class="discord-userlist discord-allusers">';

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
     <tr><td>join<br/><strong>[Boolean]</strong></td><td>Determines whether to show the Join Server button within the widget.</td><td>true</td></tr>
     <tr><td>alphabetical<br/><strong>[Boolean]</strong></td><td>Determines whether the channel list will display in alphabetical order or not.</td><td>false</td></tr>
     <tr><td>theme<br/><strong>[String ('light', 'dark', 'none')]</strong></td><td>Pick your poison!<br/><br/>'none' removes <strong>all styling</strong>, including margins and padding around the widget.</td><td>light</td></tr>
-    <tr><td>hideChannels<br/><strong>[String Array]</strong></td><td>Hide channels. If the channel name contains the string provided, it will be hidden.</td><td>false</td></tr>
+    <tr><td>hideChannels<br/><strong>[String Array]</strong>  -or- <strong>[Boolean]</strong></td><td>Hide channels. If the channel name contains the string provided, it will be hidden. If set to <strong>true</strong>, no channels will be displayed.</td><td>false</td></tr>
     <tr><td>showAllUsers<br/><strong>[Boolean]</strong></td><td>Show all online users, even if they are not in a voice channel.</td><td>false</td></tr>
     <tr><td>allUsersDefaultState<br/><strong>[Boolean]</strong></td><td>Sets whether the Online Users section is expanded or not by default.</td><td>true</td></tr>
     <tr><td>showNick<br/><strong>[Boolean]</strong></td><td>Sets whether the the users' server nick name shows or not.</td><td>false</td></tr>


### PR DESCRIPTION
I updated the widget to allow for specifying `true` for `hideChannels`. This makes it easy to hide _all_ widgets and just display the number of Users Online.

The only thing I changed was wrapping the sorting of channels in `if(typeof(p.hideChannels) !== 'boolean' || !p.hideChannels) {...}`. The rest of the changes in `discord.js` are increasing the indentation on the existing code.

I also updated the `index.html` file to include documentation on the new value.
